### PR TITLE
After installing via 'apt-get install webradio.py' I ended up with a …

### DIFF
--- a/etc/systemd/system/webradio.service
+++ b/etc/systemd/system/webradio.service
@@ -12,7 +12,7 @@ Environment="DISPLAY=:0"
 Environment="XAUTHORITY=/home/pi/.Xauthority"
 User=pi
 Type=simple
-ExecStart=/usr/bin/sudo /usr/bin/python /opt/webradio/webradio.py
+ExecStart=/usr/bin/sudo /usr/bin/python /opt/webradio/webradio.py --fullscreen
 RestartSec=5
 Restart=on-failure
 StartLimitInterval=20


### PR DESCRIPTION
…webradio that looked like fullscreen but was lacking one pixel on top and one to the left. After adding this command line switch this was gone.